### PR TITLE
add sublevel param & refactor cubical + add example + relax validate_PHom

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,7 +71,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 URL: https://github.com/tdaverse/ripserr/
 BugReports: https://github.com/tdaverse/ripserr/issues
 LinkingTo: Rcpp

--- a/R/PHom.R
+++ b/R/PHom.R
@@ -60,16 +60,6 @@ validate_PHom <- function(x, error = TRUE) {
     }
   }
   
-  # make sure all deaths are after corresponding births
-  if (!all(x$birth < x$death)) {
-    if (error) {
-      stop(paste("In PHom objects, all births must be before corresponding",
-                 "deaths."))
-    } else {
-      return(FALSE)
-    }
-  }
-  
   # return original object if all okay (or TRUE)
   if (error) {
     x

--- a/R/cubical.R
+++ b/R/cubical.R
@@ -12,7 +12,10 @@
 #' previous versions of `R`, in which objects with class `matrix` do not
 #' necessarily also have class `array`, `dataset` is converted to an `array`
 #' and persistent homology is then calculated using `cubical.array`.
-#'
+#' 
+#' Note that the superlevel set filtration (`sublevel = FALSE`) will yield a
+#' persistence diagram in which `death` precedes `birth`.
+#' 
 #' @title Calculating Persistent Homology via a Cubical Complex
 #' @param dataset object on which to calculate persistent homology
 #' @param ... other relevant parameters
@@ -34,6 +37,10 @@
 #' # 4-dim example
 #' dataset <- rnorm(5 ^ 4)
 #' dim(dataset) <- rep(5, 4)
+#' 
+#' # sublevel versus superlevel
+#' cubical(volcano)
+#' cubical(volcano, sublevel = FALSE)
 # Notes:
 # - figure out format from `dataset`
 # - return_format will be "df" (opinionated) w/ additional "PHom" S3 class
@@ -47,13 +54,26 @@ cubical <- function(dataset, ...) {
 #' @param threshold maximum simplicial complex diameter to explore
 #' @param method either `"lj"` (for Link Join) or `"cp"` (for Compute Pairs);
 #'   see Kaji et al. (2020) <https://arxiv.org/abs/2005.12692> for details
+#' @param sublevel logical; whether to take the sublevel set filtration or else
+#'   the superlevel set filtration
 #' @export cubical.array
 #' @export
-cubical.array <- function(dataset, threshold = 9999, method = "lj", ...) {
+cubical.array <- function(
+    dataset,
+    threshold = 9999, method = "lj",
+    sublevel = TRUE,
+    ...
+) {
+  # do this before checks since it modifies `dataset`
+  if (! is.logical(sublevel) || is.na(sublevel))
+    stop("`sublevel` must be `TRUE` or `FALSE`.")
+  if (! sublevel) dataset <- -dataset
+  
   # ensure valid arguments passed
   validate_params_cub(threshold = threshold,
                       method = method)
   validate_arr_cub(dataset)
+  
   
   # transform method parameter for C++ function
   method_int <- switch(method,
@@ -88,19 +108,20 @@ cubical.array <- function(dataset, threshold = 9999, method = "lj", ...) {
                                dim(dataset)[4])
                 })
   
+  # INEFFICIENT COPYING STEP, TRY TO FIND A WAY AROUND THIS, IF POSSIBLE
+  # remove unnecessary feature (dim = -1, birth = min value, death = threshold)
+  remove_row <- which(ans[, 1L] == -1 &
+            close_numeric(ans[, 2L], min(dataset)) &
+            close_numeric(ans[, 3L], threshold))
+  if (is.integer(remove_row) & length(remove_row) == 1L)
+    ans <- ans[-remove_row, , drop = FALSE]
+  
+  if (! sublevel) ans[, c(2L, 3L)] <- -ans[, c(2L, 3L)]
+  
   # properly format persistent homology output
   ans <- as.data.frame(ans)
   colnames(ans) <- c("dimension", "birth", "death")
   ans$dimension <- as.integer(ans$dimension)
-  
-  # INEFFICIENT COPYING STEP, TRY TO FIND A WAY AROUND THIS, IF POSSIBLE
-  # remove unnecessary feature (dim = -1, birth = min value, death = threshold)
-  remove_row <- which(ans$dimension == -1 &
-                      close_numeric(ans$birth, min(dataset)) &
-                      close_numeric(ans$death, threshold))
-  if (is.integer(remove_row) & length(remove_row) == 1) {
-    ans <- ans[-remove_row, ]
-  }
   
   # convert data frame to a PHom object
   ans <- new_PHom(ans)

--- a/man/cubical.Rd
+++ b/man/cubical.Rd
@@ -8,7 +8,7 @@
 \usage{
 cubical(dataset, ...)
 
-\method{cubical}{array}(dataset, threshold = 9999, method = "lj", ...)
+\method{cubical}{array}(dataset, threshold = 9999, method = "lj", sublevel = TRUE, ...)
 
 \method{cubical}{matrix}(dataset, ...)
 }
@@ -21,6 +21,9 @@ cubical(dataset, ...)
 
 \item{method}{either \code{"lj"} (for Link Join) or \code{"cp"} (for Compute Pairs);
 see Kaji et al. (2020) \url{https://arxiv.org/abs/2005.12692} for details}
+
+\item{sublevel}{logical; whether to take the sublevel set filtration or else
+the superlevel set filtration}
 }
 \value{
 \code{PHom} object
@@ -41,6 +44,9 @@ element in the \code{array}.
 previous versions of \code{R}, in which objects with class \code{matrix} do not
 necessarily also have class \code{array}, \code{dataset} is converted to an \code{array}
 and persistent homology is then calculated using \code{cubical.array}.
+
+Note that the superlevel set filtration (\code{sublevel = FALSE}) will yield a
+persistence diagram in which \code{death} precedes \code{birth}.
 }
 \examples{
 
@@ -57,4 +63,8 @@ cubical_hom3 <- cubical(dataset)
 # 4-dim example
 dataset <- rnorm(5 ^ 4)
 dim(dataset) <- rep(5, 4)
+
+# sublevel versus superlevel
+cubical(volcano)
+cubical(volcano, sublevel = FALSE)
 }


### PR DESCRIPTION
This PR introduces a simple trick to compute superlevel set cubical filtrations of rasters by inverting the input data before the C++ call and post-processing the birth and death values of the output.